### PR TITLE
Removed '| None' from the type hinting on check_for_known_access_poin…

### DIFF
--- a/njord.py
+++ b/njord.py
@@ -207,7 +207,7 @@ class NJORD:
         except KeyError as e:
             raise KeyError(f"Missing required key in configuration data: {e}")
 
-    def check_for_known_access_points(self, aos_resp: dict) -> dict | None:
+    def check_for_known_access_points(self, aos_resp: dict) -> dict:
         """
         Checks if a known access point is in range and returns its position.
 


### PR DESCRIPTION
Removed '| None' from type hinting in the defition for check_for_known_access_points.  Closing #2 