### PR TITLE
added caching of matched AP

### DIFF
--- a/aosapi/aosquerykeys.py
+++ b/aosapi/aosquerykeys.py
@@ -28,3 +28,4 @@ class AOSQueryKeys:
     GNSS = "location.gnss"
     WIFI = "net.wifi.ssid"
     INTERFACE = "net.interface"
+    IGNITION_STATUS = "vehicle.can.ignitionstatus"

--- a/njord.py
+++ b/njord.py
@@ -264,7 +264,7 @@ class NJORD:
             Exception: If an unexpected error occurs during processing.
         """
         try:
-            fields = [AOSKeys.QUERY.GNSS, AOSKeys.QUERY.WIFI, AOSKeys.QUERY.INTERFACE, "vehicle.can.ignitionstatus"]
+            fields = [AOSKeys.QUERY.GNSS, AOSKeys.QUERY.WIFI, AOSKeys.QUERY.INTERFACE, AOSKeys.QUERY.IGNITION_STATUS]
             aos_resp = self.AOSClient.get_data(fields)
 
             # Calculate TAIP Data Source
@@ -308,7 +308,7 @@ class NJORD:
                 self.debug_msg(f'Sending GNSS data based on GNSS HDOP ({aos_resp[AOSKeys.GNSS.HDOP]:.1f}) < Excellent Threshold ({self.hdop_excellent_threshold})')
                 return True
             
-            ignition_status = aos_resp["vehicle.can.ignitionstatus"]
+            ignition_status = aos_resp[AOSKeys.QUERY.IGNITION_STATUS]
             if self.cached_ap_info is not None and ignition_status == "on":
                     self.debug_msg("Ignition is on; clearing cached AP info.")
                     self.cached_ap_info = None

--- a/njord.py
+++ b/njord.py
@@ -316,9 +316,10 @@ class NJORD:
             
             #if there's still cached AP info, use it and early return
             if self.cached_ap_info is not None:
+                self.debug_msg("Using cached AP info.")
                 self.gnss.set_basic_values(fixtime=None,
-                                          latitude=ap_info['Latitude'],
-                                          longitude=ap_info['Longitude'],
+                                          latitude=self.cached_ap_info['Latitude'],
+                                          longitude=self.cached_ap_info['Longitude'],
                                           heading=0,
                                           speed=0,
                                           speed_units='ms',

--- a/njord.py
+++ b/njord.py
@@ -123,7 +123,7 @@ class NJORD:
                  aos_url: str = None, config_url: str = None, aos_username: str = None,
                  aos_password: str = None, hdop_excellent_threshold: float = None,
                  hdop_poor_threshold: float = None, num_wifi_scans: int = 1,
-                 wifi_scan_interval: int = 1, debug: bool = False):
+                 wifi_scan_interval: int = 1,cache_ap_matches:bool=False, debug: bool = False):
         """
         Initialize the NJORD instance with configuration and API details.
 
@@ -158,9 +158,10 @@ class NJORD:
         self.hdop_poor_threshold = hdop_poor_threshold
         self.num_wifi_scans = num_wifi_scans
         self.wifi_scan_interval = wifi_scan_interval
+        self.cache_ap_matches = cache_ap_matches
+        self.cached_ap_info = None
         self.taip_id = '0000'
         self.debug = debug
-        self.cached_ap_info = None
         
         # This is a hack to accomadate the Central Square Mobile Clinets
         self.gnss.age = TAIP.Age.FRESH
@@ -345,7 +346,8 @@ class NJORD:
                                           speed=0,
                                           speed_units='ms',
                                           source=9)
-                    self.cached_ap_info = ap_info
+                    if self.cache_ap_matches == True:
+                        self.cached_ap_info = ap_info
                     return True
                 wifi_scan_count += 1
 
@@ -636,7 +638,12 @@ def parse_arguments():
     parser.add_argument(
         '-D', '--hdop-poor-threshold',
         type=float,
-        help="When GNSS data has a HDOP greather than this value, the GNSS data is ignored as invalid.")    
+        help="When GNSS data has a HDOP greather than this value, the GNSS data is ignored as invalid.")
+
+    parser.add_argument(
+        '-k', '--cache-ap-matches',
+        action='store_true',
+        help="Cache access point matches when vehicle ignition status is off.")    
 
     return parser.parse_args()
 
@@ -783,6 +790,7 @@ def main():
                 hdop_poor_threshold=args.hdop_poor_threshold,
                 num_wifi_scans=args.num_wifi_scan,
                 wifi_scan_interval=args.wifi_scan_delay,
+                cache_ap_matches=args.cache_ap_matches,
                 debug=args.verbose)
 
     messenger = {'message_type': args.messagetype.upper(), 'carrier': None}


### PR DESCRIPTION
took a stab at caching a matched AP as long as the ignition is off.  If we know the vehicle is off, it's not moving, so it's safe to rely on a previously found AP.  As soon as the ignition sense is on, it clears the cache.

I wasn't sure the best way to address the new query value, give it's just one.  Wasn't sure if we should be defining it in the Keys like all of the other ones.  Probably, right?